### PR TITLE
Feature test backend performance

### DIFF
--- a/controllers/v1/gardens/gardens_controller.go
+++ b/controllers/v1/gardens/gardens_controller.go
@@ -11,12 +11,14 @@ import (
 	completed_tasks_models "github.com/ice-cream-backend/models/v1/completed_tasks"
 	gardens_models "github.com/ice-cream-backend/models/v1/gardens"
 	rules_models "github.com/ice-cream-backend/models/v1/rules"
+	"github.com/ice-cream-backend/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func CreateGardens(createdGardensPost gardens_models.Gardens) (*mongo.InsertOneResult, error) {
+	start := utils.StartPerformanceTest()
 	ctx := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
@@ -33,10 +35,12 @@ func CreateGardens(createdGardensPost gardens_models.Gardens) (*mongo.InsertOneR
 		log.Println("Error creating new createGardens:", insertErr)
 	}
 
+	utils.StopPerformanceTest(start, "Successful create garden (controller)")
 	return res, insertErr
 }
 
 func GetGardensByGardenId(createGardenId interface{}) (gardens_models.Gardens, error) {
+	start := utils.StartPerformanceTest()
 	ctx := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
@@ -54,6 +58,7 @@ func GetGardensByGardenId(createGardenId interface{}) (gardens_models.Gardens, e
 		log.Println("err in findOne:", err)
 	}
 
+	utils.StopPerformanceTest(start, "Successful get gardensByGardenId (controller)")
 	return result, err
 }
 

--- a/controllers/v1/rules/rules_controllers.go
+++ b/controllers/v1/rules/rules_controllers.go
@@ -7,6 +7,7 @@ import (
 
 	mongo_connection "github.com/ice-cream-backend/database"
 	rules_models "github.com/ice-cream-backend/models/v1/rules"
+	"github.com/ice-cream-backend/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -34,6 +35,7 @@ func CreateRule(rulesPost rules_models.Rules) (*mongo.InsertOneResult, error) {
 }
 
 func CreateRules(multipleRulesPost []rules_models.Rules) (*mongo.InsertManyResult, error) {
+	start := utils.StartPerformanceTest()
 	ctx := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
@@ -55,6 +57,7 @@ func CreateRules(multipleRulesPost []rules_models.Rules) (*mongo.InsertManyResul
 		log.Println("Error creating new rule:", insertErr)
 	}
 
+	utils.StopPerformanceTest(start, "Successful create rules (controller)")
 	return res, insertErr
 }
 
@@ -76,6 +79,7 @@ func GetRulesByRuleId(ruleId interface{}) rules_models.Rules {
 }
 
 func GetRulesByRuleIds(ruleIds []interface{}) []rules_models.Rules {
+	start := utils.StartPerformanceTest()
 	ctx := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
@@ -96,6 +100,7 @@ func GetRulesByRuleIds(ruleIds []interface{}) []rules_models.Rules {
 		log.Println(cursorErr)
 	}
 
+	utils.StopPerformanceTest(start, "Successful get rulesByRuleIds (controller)")
 	return results
 }
 

--- a/routes/v1/gardens/gardens_router.go
+++ b/routes/v1/gardens/gardens_router.go
@@ -28,10 +28,17 @@ func CreateGardens(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			fmt.Fprintf(w, "Error creating garden!")
 		} else {
-			newGarden := gardens_controllers.GetGardensByGardenId(res.InsertedID)
+			newGarden, err := gardens_controllers.GetGardensByGardenId(res.InsertedID)
 
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(newGarden)
+			if err != nil {
+				var iceCreamError errors_models.IceCreamErrors
+				iceCreamError.Error = err.Error()
+				iceCreamError.Info = "Invalid gardenId provided"
+				json.NewEncoder(w).Encode(iceCreamError)
+			} else {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(newGarden)
+			}
 		}
 	}
 }
@@ -49,10 +56,17 @@ func GetGardenByGardenId(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode("Invalid gardenId provided")
 	} else {
-		populatedGarden := gardens_controllers.GetPopulatedGardenByGardenId(oid)
+		populatedGarden, err := gardens_controllers.GetPopulatedGardenByGardenId(oid)
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(populatedGarden)
+		if err != nil {
+			var iceCreamError errors_models.IceCreamErrors
+			iceCreamError.Error = err.Error()
+			iceCreamError.Info = "Invalid gardenId provided"
+			json.NewEncoder(w).Encode(iceCreamError)
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(populatedGarden)
+		}
 	}
 }
 
@@ -62,6 +76,10 @@ func GetGardensByUserId(w http.ResponseWriter, r *http.Request) {
 	paramsUserId := vars["userFireBaseId"]
 
 	userGardens := gardens_controllers.GetGardensByUserId(paramsUserId)
+
+	if len(userGardens) == 0 {
+		userGardens = []gardens_models.Gardens{}
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(userGardens)
@@ -99,7 +117,7 @@ func UpdateGardenById(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if res.MatchedCount != 0 {
-			updatedGarden := gardens_controllers.GetGardensByGardenId(oid)
+			updatedGarden, _ := gardens_controllers.GetGardensByGardenId(oid)
 
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(updatedGarden)

--- a/routes/v1/gardens/gardens_router.go
+++ b/routes/v1/gardens/gardens_router.go
@@ -19,6 +19,7 @@ func CreateGardens(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Endpoint hit: create gardens for method:", r.Method)
 	utils.EnableCors(&w)
 	if r.Method == "POST" {
+		start := utils.StartPerformanceTest()
 
 		var createdGardensPost gardens_models.Gardens
 		_ = json.NewDecoder(r.Body).Decode(&createdGardensPost)
@@ -38,6 +39,7 @@ func CreateGardens(w http.ResponseWriter, r *http.Request) {
 			} else {
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(newGarden)
+				utils.StopPerformanceTest(start, "Successful create garden took")
 			}
 		}
 	}

--- a/routes/v1/gardens/gardens_router.go
+++ b/routes/v1/gardens/gardens_router.go
@@ -46,6 +46,7 @@ func CreateGardens(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetGardenByGardenId(w http.ResponseWriter, r *http.Request) {
+	start := utils.StartPerformanceTest()
 	vars := mux.Vars(r)
 	utils.EnableCors(&w)
 
@@ -68,6 +69,7 @@ func GetGardenByGardenId(w http.ResponseWriter, r *http.Request) {
 		} else {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(populatedGarden)
+			utils.StopPerformanceTest(start, fmt.Sprintf("Successfully got fully populated garden for gardenId %s ", paramsGardenId))
 		}
 	}
 }

--- a/routes/v1/rules/rules_routes.go
+++ b/routes/v1/rules/rules_routes.go
@@ -39,6 +39,7 @@ func CreateRules(w http.ResponseWriter, r *http.Request) {
 	utils.EnableCors(&w)
 
 	if r.Method == "POST" {
+		start := utils.StartPerformanceTest()
 		var multipleRulesPost []rules_models.Rules
 		_ = json.NewDecoder(r.Body).Decode(&multipleRulesPost)
 	
@@ -51,6 +52,7 @@ func CreateRules(w http.ResponseWriter, r *http.Request) {
 	
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(newRules)
+			utils.StopPerformanceTest(start, "Successful create rules (routes)")
 		}
 	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -22,4 +23,13 @@ func EnableCors(w *http.ResponseWriter) {
 	header.Set("Access-Control-Allow-Origin", "*")
 	header.Set("Access-Control-Allow-Methods", "DELETE, POST, GET, OPTIONS")
 	header.Set("Access-Control-Allow-Headers", "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With")
+}
+
+func StartPerformanceTest() time.Time {
+	return time.Now()
+}
+
+func StopPerformanceTest(start time.Time, message string) {
+	elapsed := time.Since(start)
+	log.Printf("%s took %s", message, elapsed)
 }


### PR DESCRIPTION
## Description

Add stopwatch logs for key create / get calls to see how long it takes on the staging server versus the local server.
So far I put it on the below API calls
- Create Garden
- Create bulk rules
- Get Garden by Garden Id (fully populated)

## Closes issue(s)

#69 

## How to test / reproduce

## Screenshots

<img width="1280" alt="スクリーンショット 2021-09-02 21 16 58" src="https://user-images.githubusercontent.com/770480/131841982-0e79ecd5-cdd9-490e-b023-1b96659de075.png">

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [X] I have tested this code

## Other comments
