### PR TITLE
Feature fix context timeout

### DIFF
--- a/controllers/v1/completed_tasks/completed_tasks_controllers.go
+++ b/controllers/v1/completed_tasks/completed_tasks_controllers.go
@@ -14,10 +14,11 @@ import (
 )
 
 func CreateCompletedTask(completedTasksPost completed_tasks_models.CompletedTasks) (*mongo.InsertOneResult, error) {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "completedTasks")
 
@@ -34,10 +35,11 @@ func CreateCompletedTask(completedTasksPost completed_tasks_models.CompletedTask
 }
 
 func GetCompletedTasksByCompletedTaskId(completedTaskId interface{}) completed_tasks_models.CompletedTasks {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "completedTasks")
 
@@ -51,10 +53,11 @@ func GetCompletedTasksByCompletedTaskId(completedTaskId interface{}) completed_t
 }
 
 func GetCompletedTasksByRuleIds(ruleIds []interface{}) []completed_tasks_models.CompletedTasks {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "completedTasks")
 
@@ -78,10 +81,11 @@ func GetCompletedTasksByRuleIds(ruleIds []interface{}) []completed_tasks_models.
 }
 
 func DeleteCompletedTaskByCompletedTaskId(completedTaskId interface{}) (*mongo.DeleteResult, error) {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "completedTasks")
 

--- a/controllers/v1/flowers/gardens_controller.go
+++ b/controllers/v1/flowers/gardens_controller.go
@@ -10,10 +10,11 @@ import (
 )
 
 func GetFlowers() []flowers_models.Flowers {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "flowers")
 

--- a/controllers/v1/gardens/gardens_controller.go
+++ b/controllers/v1/gardens/gardens_controller.go
@@ -19,10 +19,11 @@ import (
 
 func CreateGardens(createdGardensPost gardens_models.Gardens) (*mongo.InsertOneResult, error) {
 	start := utils.StartPerformanceTest()
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "gardens")
 
@@ -41,10 +42,11 @@ func CreateGardens(createdGardensPost gardens_models.Gardens) (*mongo.InsertOneR
 
 func GetGardensByGardenId(createGardenId interface{}) (gardens_models.Gardens, error) {
 	start := utils.StartPerformanceTest()
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "gardens")
 
@@ -93,10 +95,11 @@ func GetPopulatedGardenByGardenId(gardenId interface{}) (gardens_models.GardensF
 }
 
 func GetGardensByUserId(userFireBaseId interface{}) []gardens_models.Gardens {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "gardens")
 
@@ -119,10 +122,11 @@ func GetGardensByUserId(userFireBaseId interface{}) []gardens_models.Gardens {
 }
 
 func UpdateGardenByGardenId(gardenId interface{}, garden gardens_models.Gardens) (*mongo.UpdateResult, error) {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "gardens")
 
@@ -140,10 +144,11 @@ func UpdateGardenByGardenId(gardenId interface{}, garden gardens_models.Gardens)
 }
 
 func DeleteGardenByGardenId(gardenId interface{}) (*mongo.DeleteResult, error) {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "gardens")
 

--- a/controllers/v1/rules/rules_controllers.go
+++ b/controllers/v1/rules/rules_controllers.go
@@ -15,10 +15,11 @@ import (
 )
 
 func CreateRule(rulesPost rules_models.Rules) (*mongo.InsertOneResult, error) {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "rules")
 
@@ -36,10 +37,11 @@ func CreateRule(rulesPost rules_models.Rules) (*mongo.InsertOneResult, error) {
 
 func CreateRules(multipleRulesPost []rules_models.Rules) (*mongo.InsertManyResult, error) {
 	start := utils.StartPerformanceTest()
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "rules")
 
@@ -62,10 +64,11 @@ func CreateRules(multipleRulesPost []rules_models.Rules) (*mongo.InsertManyResul
 }
 
 func GetRulesByRuleId(ruleId interface{}) rules_models.Rules {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "rules")
 
@@ -80,10 +83,11 @@ func GetRulesByRuleId(ruleId interface{}) rules_models.Rules {
 
 func GetRulesByRuleIds(ruleIds []interface{}) []rules_models.Rules {
 	start := utils.StartPerformanceTest()
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "rules")
 
@@ -105,10 +109,11 @@ func GetRulesByRuleIds(ruleIds []interface{}) []rules_models.Rules {
 }
 
 func GetRulesByGardenId(gardenId interface{}) []rules_models.Rules {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "rules")
 
@@ -131,10 +136,11 @@ func GetRulesByGardenId(gardenId interface{}) []rules_models.Rules {
 }
 
 func UpdateRuleByRuleId(ruleId interface{}, rule rules_models.Rules) (*mongo.UpdateResult, error) {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "rules")
 
@@ -153,10 +159,11 @@ func UpdateRuleByRuleId(ruleId interface{}, rule rules_models.Rules) (*mongo.Upd
 }
 
 func DeleteRulesByGardenId(gardenId interface{}) (*mongo.DeleteResult, error) {
-	ctx := mongo_connection.ContextForMongo()
+	ctx, ctxCancel := mongo_connection.ContextForMongo()
 	client := mongo_connection.MongoConnection(ctx)
 
 	defer client.Disconnect(ctx)
+	defer ctxCancel()
 
 	collection := mongo_connection.MongoCollection(client, "rules")
 

--- a/database/mongo_connection.go
+++ b/database/mongo_connection.go
@@ -16,9 +16,9 @@ func mongoErrorHandling(err error)  {
 	}
 }
 
-func ContextForMongo() context.Context {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	return ctx
+func ContextForMongo() (context.Context, context.CancelFunc) {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	return ctx, ctxCancel
 }
 
 func MongoConnection(ctx context.Context) mongo.Client {


### PR DESCRIPTION
## Description

The MongoDB's context has a cancel function that wasn't utilized. It shouldn't be a big problem but it should release the resource if the MongoDB context is complete.

## Closes issue(s)

Closes #34 

## How to test / reproduce

## Screenshots


## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [X] I have tested this code

## Other comments
